### PR TITLE
Topic Hash calculators should include implementation addresses now

### DIFF
--- a/docs/components/topic-calculator.js
+++ b/docs/components/topic-calculator.js
@@ -73,8 +73,18 @@ class TopicApp extends React.Component {
 
 
   _renderEvents = () => {
-   if (this.state.events !== undefined){
-    let items = this.state.events.data.items[0].abi_items;
+   if (this.state.events !== undefined) { 
+    let items;
+    for (var i = 0; i < this.state.events.data.items.length; i++) { 
+      if ("contract_address" in this.state.events.data.items[i]) {
+        if (items === undefined) {
+          items = this.state.events.data.items[i].abi_items;
+        } else {
+          items = items.concat(this.state.events.data.items[i].abi_items);
+        }
+      }
+    }
+    // let items = this.state.events.data.items[0].abi_items;
     let a = items.filter((item)=> {
       return item.signature !==null;
     })


### PR DESCRIPTION
0x398eC7346DcD622eDc5ae82352F02bE94C62d119 before had two events that were "Admin Changed(address previous Admin, address new Admin)" and "Upgraded(indexed address implementation)".  Now it should have 13 events since it now should include the implementation contract address's events as well. 